### PR TITLE
Add error types for range proof and sigma proofs

### DIFF
--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -5,14 +5,6 @@ use thiserror::Error;
 pub enum ProofError {
     #[error("proof failed to verify")]
     VerificationError,
-    #[error("malformed proof")]
-    FormatError,
-    #[error("number of blinding factors do not match the number of values")]
-    WrongNumBlindingFactors,
-    #[error("attempted to create a proof with bitsize other than \\(8\\), \\(16\\), \\(32\\), or \\(64\\)")]
-    InvalidBitsize,
-    #[error("insufficient generators for the proof")]
-    InvalidGeneratorsLength,
     #[error(
         "`zk_token_elgamal::pod::ElGamalCiphertext` contains invalid ElGamalCiphertext ciphertext"
     )]

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -1,19 +1,16 @@
 //! Errors related to proving and verifying proofs.
+use crate::{range_proof::errors::RangeProofError, sigma_proofs::errors::*};
 use thiserror::Error;
-use crate::{
-    range_proof::errors::RangeProofError,
-    sigma_proofs::errors::*,
-};
 
 // TODO: clean up errors for encryption
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofError {
     #[error("proof failed to verify")]
-    VerificationError,
+    Verification,
     #[error("range proof failed to verify")]
-    RangeProofError,
+    RangeProof,
     #[error("sigma proof failed to verify")]
-    SigmaProofError,
+    SigmaProof,
     #[error(
         "`zk_token_elgamal::pod::ElGamalCiphertext` contains invalid ElGamalCiphertext ciphertext"
     )]
@@ -28,29 +25,29 @@ pub enum TranscriptError {
 
 impl From<RangeProofError> for ProofError {
     fn from(_err: RangeProofError) -> Self {
-        Self::RangeProofError
+        Self::RangeProof
     }
 }
 
 impl From<EqualityProofError> for ProofError {
     fn from(_err: EqualityProofError) -> Self {
-        Self::SigmaProofError
+        Self::SigmaProof
     }
 }
 
 impl From<FeeProofError> for ProofError {
     fn from(_err: FeeProofError) -> Self {
-        Self::SigmaProofError
+        Self::SigmaProof
     }
 }
 
 impl From<ZeroBalanceProofError> for ProofError {
     fn from(_err: ZeroBalanceProofError) -> Self {
-        Self::SigmaProofError
+        Self::SigmaProof
     }
 }
 impl From<ValidityProofError> for ProofError {
     fn from(_err: ValidityProofError) -> Self {
-        Self::SigmaProofError
+        Self::SigmaProof
     }
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -1,7 +1,11 @@
 //! Errors related to proving and verifying proofs.
 use thiserror::Error;
-use crate::range_proof::errors::RangeProofError;
+use crate::{
+    range_proof::errors::RangeProofError,
+    sigma_proofs::errors::*,
+};
 
+// TODO: clean up errors for encryption
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofError {
     #[error("proof failed to verify")]
@@ -23,7 +27,30 @@ pub enum TranscriptError {
 }
 
 impl From<RangeProofError> for ProofError {
-    fn from(err: RangeProofError) -> Self {
+    fn from(_err: RangeProofError) -> Self {
         Self::RangeProofError
+    }
+}
+
+impl From<EqualityProofError> for ProofError {
+    fn from(_err: EqualityProofError) -> Self {
+        Self::SigmaProofError
+    }
+}
+
+impl From<FeeProofError> for ProofError {
+    fn from(_err: FeeProofError) -> Self {
+        Self::SigmaProofError
+    }
+}
+
+impl From<ZeroBalanceProofError> for ProofError {
+    fn from(_err: ZeroBalanceProofError) -> Self {
+        Self::SigmaProofError
+    }
+}
+impl From<ValidityProofError> for ProofError {
+    fn from(_err: ValidityProofError) -> Self {
+        Self::SigmaProofError
     }
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -1,10 +1,15 @@
 //! Errors related to proving and verifying proofs.
 use thiserror::Error;
+use crate::range_proof::errors::RangeProofError;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofError {
     #[error("proof failed to verify")]
     VerificationError,
+    #[error("range proof failed to verify")]
+    RangeProofError,
+    #[error("sigma proof failed to verify")]
+    SigmaProofError,
     #[error(
         "`zk_token_elgamal::pod::ElGamalCiphertext` contains invalid ElGamalCiphertext ciphertext"
     )]
@@ -15,4 +20,10 @@ pub enum ProofError {
 pub enum TranscriptError {
     #[error("point is the identity")]
     ValidationError,
+}
+
+impl From<RangeProofError> for ProofError {
+    fn from(err: RangeProofError) -> Self {
+        Self::RangeProofError
+    }
 }

--- a/sdk/src/errors.rs
+++ b/sdk/src/errors.rs
@@ -10,3 +10,9 @@ pub enum ProofError {
     )]
     InconsistentCTData,
 }
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum TranscriptError {
+    #[error("point is the identity")]
+    ValidationError,
+}

--- a/sdk/src/instruction/close_account.rs
+++ b/sdk/src/instruction/close_account.rs
@@ -99,7 +99,8 @@ impl CloseAccountProof {
 
         // verify zero balance proof
         let proof: ZeroBalanceProof = self.proof.try_into()?;
-        proof.verify(elgamal_pubkey, balance, &mut transcript)
+        proof.verify(elgamal_pubkey, balance, &mut transcript)?;
+        Ok(())
     }
 }
 

--- a/sdk/src/instruction/transfer.rs
+++ b/sdk/src/instruction/transfer.rs
@@ -266,7 +266,7 @@ impl TransferProof {
             ValidityProof::new(dest_pk, auditor_pk, transfer_amt, openings, &mut transcript);
 
         // generate the range proof
-        let range_proof = RangeProof::create(
+        let range_proof = RangeProof::new(
             vec![source_new_balance, transfer_amt.0, transfer_amt.1],
             vec![64, 32, 32],
             vec![&source_open, openings.0, openings.1],

--- a/sdk/src/instruction/transfer.rs
+++ b/sdk/src/instruction/transfer.rs
@@ -176,7 +176,7 @@ impl TransferData {
         if let (Some(amount_lo), Some(amount_hi)) = (amount_lo, amount_hi) {
             Ok((amount_lo as u64) + (TWO_32 * amount_hi as u64))
         } else {
-            Err(ProofError::VerificationError)
+            Err(ProofError::Verification)
         }
     }
 }

--- a/sdk/src/instruction/withdraw.rs
+++ b/sdk/src/instruction/withdraw.rs
@@ -136,7 +136,7 @@ impl WithdrawProof {
             &mut transcript,
         );
 
-        let range_proof = RangeProof::create(
+        let range_proof = RangeProof::new(
             vec![final_balance],
             vec![64],
             vec![&opening],

--- a/sdk/src/range_proof/errors.rs
+++ b/sdk/src/range_proof/errors.rs
@@ -1,27 +1,27 @@
 //! Errors related to proving and verifying range proofs.
-use thiserror::Error;
 use crate::errors::TranscriptError;
+use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum RangeProofError {
     #[error("the required algebraic relation does not hold")]
-    AlgebraicRelationError,
+    AlgebraicRelation,
     #[error("malformed proof")]
-    FormatError,
+    Format,
     #[error("attempted to create a proof with a non-power-of-two bitsize or bitsize too big")]
     InvalidBitsize,
     #[error("insufficient generators for the proof")]
     InvalidGeneratorsLength,
     #[error("multiscalar multiplication failed")]
-    MultiscalarMulError,
+    MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
-    TranscriptError,
+    Transcript,
     #[error("number of blinding factors do not match the number of values")]
     WrongNumBlindingFactors,
 }
 
 impl From<TranscriptError> for RangeProofError {
     fn from(_err: TranscriptError) -> Self {
-        Self::TranscriptError
+        Self::Transcript
     }
 }

--- a/sdk/src/range_proof/errors.rs
+++ b/sdk/src/range_proof/errors.rs
@@ -1,4 +1,4 @@
-//! Errors related to proving and verifying proofs.
+//! Errors related to proving and verifying range proofs.
 use thiserror::Error;
 use crate::errors::TranscriptError;
 
@@ -8,10 +8,12 @@ pub enum RangeProofError {
     AlgebraicRelationError,
     #[error("malformed proof")]
     FormatError,
-    #[error("attempted to create a proof with a non-power-of-two bitsize")]
+    #[error("attempted to create a proof with a non-power-of-two bitsize or bitsize too big")]
     InvalidBitsize,
     #[error("insufficient generators for the proof")]
     InvalidGeneratorsLength,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMulError,
     #[error("transcript failed to produce a challenge")]
     TranscriptError,
     #[error("number of blinding factors do not match the number of values")]

--- a/sdk/src/range_proof/errors.rs
+++ b/sdk/src/range_proof/errors.rs
@@ -21,7 +21,7 @@ pub enum RangeProofError {
 }
 
 impl From<TranscriptError> for RangeProofError {
-    fn from(err: TranscriptError) -> Self {
+    fn from(_err: TranscriptError) -> Self {
         Self::TranscriptError
     }
 }

--- a/sdk/src/range_proof/errors.rs
+++ b/sdk/src/range_proof/errors.rs
@@ -1,8 +1,9 @@
 //! Errors related to proving and verifying proofs.
 use thiserror::Error;
+use crate::errors::TranscriptError;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ProofError {
+pub enum RangeProofError {
     #[error("the required algebraic relation does not hold")]
     AlgebraicRelationError,
     #[error("malformed proof")]
@@ -11,6 +12,14 @@ pub enum ProofError {
     InvalidBitsize,
     #[error("insufficient generators for the proof")]
     InvalidGeneratorsLength,
+    #[error("transcript failed to produce a challenge")]
+    TranscriptError,
     #[error("number of blinding factors do not match the number of values")]
     WrongNumBlindingFactors,
+}
+
+impl From<TranscriptError> for RangeProofError {
+    fn from(err: TranscriptError) -> Self {
+        Self::TranscriptError
+    }
 }

--- a/sdk/src/range_proof/errors.rs
+++ b/sdk/src/range_proof/errors.rs
@@ -1,0 +1,16 @@
+//! Errors related to proving and verifying proofs.
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ProofError {
+    #[error("the required algebraic relation does not hold")]
+    AlgebraicRelationError,
+    #[error("malformed proof")]
+    FormatError,
+    #[error("attempted to create a proof with a non-power-of-two bitsize")]
+    InvalidBitsize,
+    #[error("insufficient generators for the proof")]
+    InvalidGeneratorsLength,
+    #[error("number of blinding factors do not match the number of values")]
+    WrongNumBlindingFactors,
+}

--- a/sdk/src/range_proof/inner_product.rs
+++ b/sdk/src/range_proof/inner_product.rs
@@ -36,7 +36,7 @@ impl InnerProductProof {
     /// The lengths of the vectors must all be the same, and must all be
     /// either 0 or a power of 2.
     #[allow(clippy::too_many_arguments)]
-    pub fn create(
+    pub fn new(
         Q: &RistrettoPoint,
         G_factors: &[Scalar],
         H_factors: &[Scalar],
@@ -45,7 +45,7 @@ impl InnerProductProof {
         mut a_vec: Vec<Scalar>,
         mut b_vec: Vec<Scalar>,
         transcript: &mut Transcript,
-    ) -> InnerProductProof {
+    ) -> Self {
         // Create slices G, H, a, b backed by their respective
         // vectors.  This lets us reslice as we compress the lengths
         // of the vectors in the main loop below.
@@ -437,7 +437,7 @@ mod tests {
         let mut prover_transcript = Transcript::new(b"innerproducttest");
         let mut verifier_transcript = Transcript::new(b"innerproducttest");
 
-        let proof = InnerProductProof::create(
+        let proof = InnerProductProof::new(
             &Q,
             &G_factors,
             &H_factors,

--- a/sdk/src/range_proof/inner_product.rs
+++ b/sdk/src/range_proof/inner_product.rs
@@ -1,5 +1,8 @@
 use {
-    crate::{range_proof::{errors::RangeProofError, util}, transcript::TranscriptProtocol},
+    crate::{
+        range_proof::{errors::RangeProofError, util},
+        transcript::TranscriptProtocol,
+    },
     core::iter,
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
@@ -295,13 +298,13 @@ impl InnerProductProof {
         let Ls = self
             .L_vec
             .iter()
-            .map(|p| p.decompress().ok_or(RangeProofError::FormatError))
+            .map(|p| p.decompress().ok_or(RangeProofError::Format))
             .collect::<Result<Vec<_>, _>>()?;
 
         let Rs = self
             .R_vec
             .iter()
-            .map(|p| p.decompress().ok_or(RangeProofError::FormatError))
+            .map(|p| p.decompress().ok_or(RangeProofError::Format))
             .collect::<Result<Vec<_>, _>>()?;
 
         let expect_P = RistrettoPoint::vartime_multiscalar_mul(
@@ -320,7 +323,7 @@ impl InnerProductProof {
         if expect_P == *P {
             Ok(())
         } else {
-            Err(RangeProofError::AlgebraicRelationError)
+            Err(RangeProofError::AlgebraicRelation)
         }
     }
 
@@ -357,18 +360,18 @@ impl InnerProductProof {
     pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, RangeProofError> {
         let b = slice.len();
         if b % 32 != 0 {
-            return Err(RangeProofError::FormatError);
+            return Err(RangeProofError::Format);
         }
         let num_elements = b / 32;
         if num_elements < 2 {
-            return Err(RangeProofError::FormatError);
+            return Err(RangeProofError::Format);
         }
         if (num_elements - 2) % 2 != 0 {
-            return Err(RangeProofError::FormatError);
+            return Err(RangeProofError::Format);
         }
         let lg_n = (num_elements - 2) / 2;
         if lg_n >= 32 {
-            return Err(RangeProofError::FormatError);
+            return Err(RangeProofError::Format);
         }
 
         let mut L_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);
@@ -381,9 +384,9 @@ impl InnerProductProof {
 
         let pos = 2 * lg_n * 32;
         let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
-            .ok_or(RangeProofError::FormatError)?;
+            .ok_or(RangeProofError::Format)?;
         let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + 32..]))
-            .ok_or(RangeProofError::FormatError)?;
+            .ok_or(RangeProofError::Format)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }

--- a/sdk/src/range_proof/mod.rs
+++ b/sdk/src/range_proof/mod.rs
@@ -8,8 +8,7 @@ use {
 use {
     crate::{
         encryption::pedersen::PedersenBase,
-        errors::ProofError,
-        range_proof::{generators::BulletproofGens, inner_product::InnerProductProof},
+        range_proof::{errors::RangeProofError, generators::BulletproofGens, inner_product::InnerProductProof},
         transcript::TranscriptProtocol,
     },
     core::iter,
@@ -222,7 +221,7 @@ impl RangeProof {
         comms: Vec<&CompressedRistretto>,
         bit_lengths: Vec<usize>,
         transcript: &mut Transcript,
-    ) -> Result<(), ProofError> {
+    ) -> Result<(), RangeProofError> {
         let G = PedersenBase::default().G;
         let H = PedersenBase::default().H;
 
@@ -231,11 +230,7 @@ impl RangeProof {
         let bp_gens = BulletproofGens::new(nm);
 
         if !nm.is_power_of_two() {
-            return Err(ProofError::InvalidBitsize);
-        }
-
-        if !(nm == 8 || nm == 16 || nm == 32 || nm == 64 || nm == 128) {
-            return Err(ProofError::InvalidBitsize);
+            return Err(RangeProofError::InvalidBitsize);
         }
 
         transcript.validate_and_append_point(b"A", &self.A)?;

--- a/sdk/src/range_proof/mod.rs
+++ b/sdk/src/range_proof/mod.rs
@@ -24,6 +24,7 @@ use {
 pub mod generators;
 pub mod inner_product;
 pub mod util;
+pub mod errors;
 
 #[allow(non_snake_case)]
 #[derive(Clone)]
@@ -222,29 +223,16 @@ impl RangeProof {
         bit_lengths: Vec<usize>,
         transcript: &mut Transcript,
     ) -> Result<(), ProofError> {
-        if self
-            .verify_challenges(comms, bit_lengths, transcript)
-            .is_ok()
-        {
-            Ok(())
-        } else {
-            Err(ProofError::VerificationError)
-        }
-    }
-
-    #[allow(clippy::many_single_char_names)]
-    pub fn verify_challenges(
-        &self,
-        comms: Vec<&CompressedRistretto>,
-        bit_lengths: Vec<usize>,
-        transcript: &mut Transcript,
-    ) -> Result<(Scalar, Scalar), ProofError> {
         let G = PedersenBase::default().G;
         let H = PedersenBase::default().H;
 
         let m = bit_lengths.len();
         let nm: usize = bit_lengths.iter().sum();
         let bp_gens = BulletproofGens::new(nm);
+
+        if !nm.is_power_of_two() {
+            return Err(ProofError::InvalidBitsize);
+        }
 
         if !(nm == 8 || nm == 16 || nm == 32 || nm == 64 || nm == 128) {
             return Err(ProofError::InvalidBitsize);

--- a/sdk/src/range_proof/mod.rs
+++ b/sdk/src/range_proof/mod.rs
@@ -196,7 +196,7 @@ impl RangeProof {
         // generate challenge `c` for consistency with the verifier's transcript
         transcript.challenge_scalar(b"c");
 
-        let ipp_proof = InnerProductProof::create(
+        let ipp_proof = InnerProductProof::new(
             &Q,
             &G_factors,
             &H_factors,

--- a/sdk/src/sigma_proofs/equality_proof.rs
+++ b/sdk/src/sigma_proofs/equality_proof.rs
@@ -109,9 +109,9 @@ impl EqualityProof {
         let ww = w * w;
 
         // check that the required algebraic condition holds
-        let Y_0 = self.Y_0.decompress().ok_or(EqualityProofError::FormatError)?;
-        let Y_1 = self.Y_1.decompress().ok_or(EqualityProofError::FormatError)?;
-        let Y_2 = self.Y_2.decompress().ok_or(EqualityProofError::FormatError)?;
+        let Y_0 = self.Y_0.decompress().ok_or(EqualityProofError::Format)?;
+        let Y_1 = self.Y_1.decompress().ok_or(EqualityProofError::Format)?;
+        let Y_2 = self.Y_2.decompress().ok_or(EqualityProofError::Format)?;
 
         let check = RistrettoPoint::vartime_multiscalar_mul(
             vec![
@@ -133,7 +133,7 @@ impl EqualityProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(EqualityProofError::AlgebraicRelationError)
+            Err(EqualityProofError::AlgebraicRelation)
         }
     }
 
@@ -156,9 +156,9 @@ impl EqualityProof {
         let Y_1 = CompressedRistretto::from_slice(Y_1);
         let Y_2 = CompressedRistretto::from_slice(Y_2);
 
-        let z_s = Scalar::from_canonical_bytes(*z_s).ok_or(EqualityProofError::FormatError)?;
-        let z_x = Scalar::from_canonical_bytes(*z_x).ok_or(EqualityProofError::FormatError)?;
-        let z_r = Scalar::from_canonical_bytes(*z_r).ok_or(EqualityProofError::FormatError)?;
+        let z_s = Scalar::from_canonical_bytes(*z_s).ok_or(EqualityProofError::Format)?;
+        let z_x = Scalar::from_canonical_bytes(*z_x).ok_or(EqualityProofError::Format)?;
+        let z_r = Scalar::from_canonical_bytes(*z_r).ok_or(EqualityProofError::Format)?;
 
         Ok(EqualityProof {
             Y_0,

--- a/sdk/src/sigma_proofs/errors.rs
+++ b/sdk/src/sigma_proofs/errors.rs
@@ -1,0 +1,57 @@
+//! Errors related to proving and verifying sigma proofs.
+use thiserror::Error;
+use crate::errors::TranscriptError;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum EqualityProof {
+    #[error("the required algebraic relation does not hold")]
+    AlgebraicRelationError,
+    #[error("malformed proof")]
+    FormatError,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMulError,
+    #[error("transcript failed to produce a challenge")]
+    TranscriptError,
+}
+
+impl From<TranscriptError> for EqualityProof {
+    fn from(err: TranscriptError) -> Self {
+        Self::TranscriptError
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ValidityProof {
+    #[error("the required algebraic relation does not hold")]
+    AlgebraicRelationError,
+    #[error("malformed proof")]
+    FormatError,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMulError,
+    #[error("transcript failed to produce a challenge")]
+    TranscriptError,
+}
+
+impl From<TranscriptError> for ValidityProof {
+    fn from(err: TranscriptError) -> Self {
+        Self::TranscriptError
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ZeroBalanceProof {
+    #[error("the required algebraic relation does not hold")]
+    AlgebraicRelationError,
+    #[error("malformed proof")]
+    FormatError,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMulError,
+    #[error("transcript failed to produce a challenge")]
+    TranscriptError,
+}
+
+impl From<TranscriptError> for ZeroBalanceProof {
+    fn from(err: TranscriptError) -> Self {
+        Self::TranscriptError
+    }
+}

--- a/sdk/src/sigma_proofs/errors.rs
+++ b/sdk/src/sigma_proofs/errors.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use crate::errors::TranscriptError;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum EqualityProof {
+pub enum EqualityProofError {
     #[error("the required algebraic relation does not hold")]
     AlgebraicRelationError,
     #[error("malformed proof")]
@@ -14,14 +14,14 @@ pub enum EqualityProof {
     TranscriptError,
 }
 
-impl From<TranscriptError> for EqualityProof {
-    fn from(err: TranscriptError) -> Self {
+impl From<TranscriptError> for EqualityProofError {
+    fn from(_err: TranscriptError) -> Self {
         Self::TranscriptError
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ValidityProof {
+pub enum ValidityProofError {
     #[error("the required algebraic relation does not hold")]
     AlgebraicRelationError,
     #[error("malformed proof")]
@@ -32,14 +32,14 @@ pub enum ValidityProof {
     TranscriptError,
 }
 
-impl From<TranscriptError> for ValidityProof {
-    fn from(err: TranscriptError) -> Self {
+impl From<TranscriptError> for ValidityProofError {
+    fn from(_err: TranscriptError) -> Self {
         Self::TranscriptError
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ZeroBalanceProof {
+pub enum ZeroBalanceProofError {
     #[error("the required algebraic relation does not hold")]
     AlgebraicRelationError,
     #[error("malformed proof")]
@@ -50,8 +50,26 @@ pub enum ZeroBalanceProof {
     TranscriptError,
 }
 
-impl From<TranscriptError> for ZeroBalanceProof {
-    fn from(err: TranscriptError) -> Self {
+impl From<TranscriptError> for ZeroBalanceProofError {
+    fn from(_err: TranscriptError) -> Self {
+        Self::TranscriptError
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum FeeProofError {
+    #[error("the required algebraic relation does not hold")]
+    AlgebraicRelationError,
+    #[error("malformed proof")]
+    FormatError,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMulError,
+    #[error("transcript failed to produce a challenge")]
+    TranscriptError,
+}
+
+impl From<TranscriptError> for FeeProofError {
+    fn from(_err: TranscriptError) -> Self {
         Self::TranscriptError
     }
 }

--- a/sdk/src/sigma_proofs/errors.rs
+++ b/sdk/src/sigma_proofs/errors.rs
@@ -1,75 +1,75 @@
 //! Errors related to proving and verifying sigma proofs.
-use thiserror::Error;
 use crate::errors::TranscriptError;
+use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum EqualityProofError {
     #[error("the required algebraic relation does not hold")]
-    AlgebraicRelationError,
+    AlgebraicRelation,
     #[error("malformed proof")]
-    FormatError,
+    Format,
     #[error("multiscalar multiplication failed")]
-    MultiscalarMulError,
+    MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
-    TranscriptError,
+    Transcript,
 }
 
 impl From<TranscriptError> for EqualityProofError {
     fn from(_err: TranscriptError) -> Self {
-        Self::TranscriptError
+        Self::Transcript
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ValidityProofError {
     #[error("the required algebraic relation does not hold")]
-    AlgebraicRelationError,
+    AlgebraicRelation,
     #[error("malformed proof")]
-    FormatError,
+    Format,
     #[error("multiscalar multiplication failed")]
-    MultiscalarMulError,
+    MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
-    TranscriptError,
+    Transcript,
 }
 
 impl From<TranscriptError> for ValidityProofError {
     fn from(_err: TranscriptError) -> Self {
-        Self::TranscriptError
+        Self::Transcript
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ZeroBalanceProofError {
     #[error("the required algebraic relation does not hold")]
-    AlgebraicRelationError,
+    AlgebraicRelation,
     #[error("malformed proof")]
-    FormatError,
+    Format,
     #[error("multiscalar multiplication failed")]
-    MultiscalarMulError,
+    MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
-    TranscriptError,
+    Transcript,
 }
 
 impl From<TranscriptError> for ZeroBalanceProofError {
     fn from(_err: TranscriptError) -> Self {
-        Self::TranscriptError
+        Self::Transcript
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum FeeProofError {
     #[error("the required algebraic relation does not hold")]
-    AlgebraicRelationError,
+    AlgebraicRelation,
     #[error("malformed proof")]
-    FormatError,
+    Format,
     #[error("multiscalar multiplication failed")]
-    MultiscalarMulError,
+    MultiscalarMul,
     #[error("transcript failed to produce a challenge")]
-    TranscriptError,
+    Transcript,
 }
 
 impl From<TranscriptError> for FeeProofError {
     fn from(_err: TranscriptError) -> Self {
-        Self::TranscriptError
+        Self::Transcript
     }
 }

--- a/sdk/src/sigma_proofs/fee_proof.rs
+++ b/sdk/src/sigma_proofs/fee_proof.rs
@@ -4,7 +4,7 @@ use {
     rand::rngs::OsRng,
 };
 use {
-    crate::{errors::ProofError, transcript::TranscriptProtocol},
+    crate::{sigma_proofs::errors::FeeProofError, transcript::TranscriptProtocol},
     curve25519_dalek::{
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
@@ -172,7 +172,7 @@ impl FeeProof {
         commitment_delta_real: PedersenCommitment,
         commitment_delta_claimed: PedersenCommitment,
         transcript: &mut Transcript,
-    ) -> Result<(), ProofError> {
+    ) -> Result<(), FeeProofError> {
         // extract the relevant scalar and Ristretto points from the input
         let G = PedersenBase::default().G;
         let H = PedersenBase::default().H;
@@ -202,19 +202,19 @@ impl FeeProof {
             .fee_max_proof
             .Y_max
             .decompress()
-            .ok_or(ProofError::VerificationError)?;
+            .ok_or(FeeProofError::FormatError)?;
         let z_max = self.fee_max_proof.z_max;
 
         let Y_delta_real = self
             .fee_equality_proof
             .Y_delta_real
             .decompress()
-            .ok_or(ProofError::VerificationError)?;
+            .ok_or(FeeProofError::FormatError)?;
         let Y_delta_claimed = self
             .fee_equality_proof
             .Y_delta_claimed
             .decompress()
-            .ok_or(ProofError::VerificationError)?;
+            .ok_or(FeeProofError::FormatError)?;
         let z_x = self.fee_equality_proof.z_x;
         let z_delta_real = self.fee_equality_proof.z_delta_real;
         let z_delta_claimed = self.fee_equality_proof.z_delta_claimed;
@@ -262,7 +262,7 @@ impl FeeProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(ProofError::VerificationError)
+            Err(FeeProofError::AlgebraicRelationError)
         }
     }
 }

--- a/sdk/src/sigma_proofs/fee_proof.rs
+++ b/sdk/src/sigma_proofs/fee_proof.rs
@@ -202,19 +202,19 @@ impl FeeProof {
             .fee_max_proof
             .Y_max
             .decompress()
-            .ok_or(FeeProofError::FormatError)?;
+            .ok_or(FeeProofError::Format)?;
         let z_max = self.fee_max_proof.z_max;
 
         let Y_delta_real = self
             .fee_equality_proof
             .Y_delta_real
             .decompress()
-            .ok_or(FeeProofError::FormatError)?;
+            .ok_or(FeeProofError::Format)?;
         let Y_delta_claimed = self
             .fee_equality_proof
             .Y_delta_claimed
             .decompress()
-            .ok_or(FeeProofError::FormatError)?;
+            .ok_or(FeeProofError::Format)?;
         let z_x = self.fee_equality_proof.z_x;
         let z_delta_real = self.fee_equality_proof.z_delta_real;
         let z_delta_claimed = self.fee_equality_proof.z_delta_claimed;
@@ -262,7 +262,7 @@ impl FeeProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(FeeProofError::AlgebraicRelationError)
+            Err(FeeProofError::AlgebraicRelation)
         }
     }
 }

--- a/sdk/src/sigma_proofs/mod.rs
+++ b/sdk/src/sigma_proofs/mod.rs
@@ -1,4 +1,5 @@
 pub mod equality_proof;
+pub mod errors;
 pub mod fee_proof;
 pub mod validity_proof;
 pub mod zero_balance_proof;

--- a/sdk/src/sigma_proofs/validity_proof.rs
+++ b/sdk/src/sigma_proofs/validity_proof.rs
@@ -103,9 +103,9 @@ impl ValidityProof {
         let ww = w * w;
 
         // check the required algebraic conditions
-        let Y_0 = self.Y_0.decompress().ok_or(ValidityProofError::FormatError)?;
-        let Y_1 = self.Y_1.decompress().ok_or(ValidityProofError::FormatError)?;
-        let Y_2 = self.Y_2.decompress().ok_or(ValidityProofError::FormatError)?;
+        let Y_0 = self.Y_0.decompress().ok_or(ValidityProofError::Format)?;
+        let Y_1 = self.Y_1.decompress().ok_or(ValidityProofError::Format)?;
+        let Y_2 = self.Y_2.decompress().ok_or(ValidityProofError::Format)?;
 
         let P_dest = elgamal_pubkey_dest.get_point();
         let P_auditor = elgamal_pubkey_auditor.get_point();
@@ -133,7 +133,7 @@ impl ValidityProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(ValidityProofError::AlgebraicRelationError)
+            Err(ValidityProofError::AlgebraicRelation)
         }
     }
 
@@ -155,8 +155,8 @@ impl ValidityProof {
         let Y_1 = CompressedRistretto::from_slice(Y_1);
         let Y_2 = CompressedRistretto::from_slice(Y_2);
 
-        let z_r = Scalar::from_canonical_bytes(*z_r).ok_or(ValidityProofError::FormatError)?;
-        let z_x = Scalar::from_canonical_bytes(*z_x).ok_or(ValidityProofError::FormatError)?;
+        let z_r = Scalar::from_canonical_bytes(*z_r).ok_or(ValidityProofError::Format)?;
+        let z_x = Scalar::from_canonical_bytes(*z_x).ok_or(ValidityProofError::Format)?;
 
         Ok(ValidityProof {
             Y_0,

--- a/sdk/src/sigma_proofs/zero_balance_proof.rs
+++ b/sdk/src/sigma_proofs/zero_balance_proof.rs
@@ -89,8 +89,8 @@ impl ZeroBalanceProof {
         let w = transcript.challenge_scalar(b"w"); // w used for multiscalar multiplication verification
 
         // decompress R or return verification error
-        let Y_P = self.Y_P.decompress().ok_or(ZeroBalanceProofError::FormatError)?;
-        let Y_D = self.Y_D.decompress().ok_or(ZeroBalanceProofError::FormatError)?;
+        let Y_P = self.Y_P.decompress().ok_or(ZeroBalanceProofError::Format)?;
+        let Y_D = self.Y_D.decompress().ok_or(ZeroBalanceProofError::Format)?;
         let z = self.z;
 
         // check the required algebraic relation
@@ -102,7 +102,7 @@ impl ZeroBalanceProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(ZeroBalanceProofError::AlgebraicRelationError)
+            Err(ZeroBalanceProofError::AlgebraicRelation)
         }
     }
 
@@ -121,7 +121,7 @@ impl ZeroBalanceProof {
         let Y_P = CompressedRistretto::from_slice(Y_P);
         let Y_D = CompressedRistretto::from_slice(Y_D);
 
-        let z = Scalar::from_canonical_bytes(*z).ok_or(ZeroBalanceProofError::FormatError)?;
+        let z = Scalar::from_canonical_bytes(*z).ok_or(ZeroBalanceProofError::Format)?;
 
         Ok(ZeroBalanceProof { Y_P, Y_D, z })
     }

--- a/sdk/src/transcript.rs
+++ b/sdk/src/transcript.rs
@@ -1,5 +1,5 @@
 use {
-    crate::errors::ProofError,
+    crate::errors::TranscriptError,
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar, traits::IsIdentity},
     merlin::Transcript,
 };
@@ -40,7 +40,7 @@ pub trait TranscriptProtocol {
         &mut self,
         label: &'static [u8],
         point: &CompressedRistretto,
-    ) -> Result<(), ProofError>;
+    ) -> Result<(), TranscriptError>;
 
     /// Compute a `label`ed challenge variable.
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar;
@@ -90,9 +90,9 @@ impl TranscriptProtocol for Transcript {
         &mut self,
         label: &'static [u8],
         point: &CompressedRistretto,
-    ) -> Result<(), ProofError> {
+    ) -> Result<(), TranscriptError> {
         if point.is_identity() {
-            Err(ProofError::VerificationError)
+            Err(TranscriptError::ValidationError)
         } else {
             self.append_message(label, point.as_bytes());
             Ok(())

--- a/sdk/src/zk_token_elgamal/convert.rs
+++ b/sdk/src/zk_token_elgamal/convert.rs
@@ -23,8 +23,7 @@ mod target_arch {
             errors::ProofError,
             range_proof::{errors::RangeProofError, RangeProof},
             sigma_proofs::{
-                errors::*,
-                equality_proof::EqualityProof, validity_proof::ValidityProof,
+                equality_proof::EqualityProof, errors::*, validity_proof::ValidityProof,
                 zero_balance_proof::ZeroBalanceProof,
             },
         },
@@ -192,7 +191,7 @@ mod target_arch {
 
         fn try_from(proof: RangeProof) -> Result<Self, Self::Error> {
             if proof.ipp_proof.serialized_size() != 448 {
-                return Err(RangeProofError::FormatError);
+                return Err(RangeProofError::Format);
             }
 
             let mut buf = [0_u8; 672];
@@ -222,7 +221,7 @@ mod target_arch {
 
         fn try_from(proof: RangeProof) -> Result<Self, Self::Error> {
             if proof.ipp_proof.serialized_size() != 512 {
-                return Err(RangeProofError::FormatError);
+                return Err(RangeProofError::Format);
             }
 
             let mut buf = [0_u8; 736];


### PR DESCRIPTION
Did a line-by-line systematic pass over range proof generation, cleaned up outdated parts of the code, and added clarifying comments for some important parts.

The code is quite involved and it is becoming harder to debug, so I added dedicated error types for range proof as well as for other proofs.

The todo's for range proof include:
- group generator computation at compile time
- double check that the generators do not interfere with the Pedersen generator for security purposes
- add additional tests for range edge cases and serialization/deserialization